### PR TITLE
Update Probe.hs

### DIFF
--- a/Data/List/Fusion/Probe.hs
+++ b/Data/List/Fusion/Probe.hs
@@ -33,7 +33,7 @@ import GHC.OldList (foldr)
 -- (These examples are from the time before GHC-7.10. Since then, 'foldl' fuses as well.)
 
 fuseThis :: [a] -> [a]
-fuseThis = id
+fuseThis ls = error "fuseThis: List did not fuse"
 
 {-# NOINLINE fuseThis #-}
 
@@ -45,10 +45,5 @@ fuseThis = id
 "foldr/fuseThis/augment" [~0]
     forall k z xs (g::forall b. (a->b->b) -> b -> b) .
     foldr k z (fuseThis (augment g xs)) = g k (foldr k z xs)
- #-}
-
-{-# RULES
-"fuseThis/fail" [0]
-    fuseThis = error "fuseThis: List did not fuse"
  #-}
 


### PR DESCRIPTION
This pull request is sort of half-question half-pull request (it only took me a couple seconds to make.)

Why do we define `fuseThis` as `id`? If no rules fire at all, then `fuseThis` won't detect the lack of list fusion.

(If it's because we want it to be easy to disable, we could make two modules, one where `fuseThis` is just `id` without anything else (this would make it safer for production code, since `id` is pretty safe.) They would use the one module whilst testing, and the other before shipping.)
